### PR TITLE
Enable dmd-nightly (and debug regressions)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ d:
 
 matrix:
   allow_failures:
-   - d: dmd-nightly
    - d: ldc-beta
 
 cache:

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -2,7 +2,7 @@
 	"fileVersion": 1,
 	"versions": {
 		"diet-ng": "1.2.1",
-		"dyaml": "0.6.1",
+		"dyaml": "0.6.2",
 		"libasync": "0.8.3",
 		"libevent": "2.0.2+2.0.16",
 		"memutils": "0.4.9",


### PR DESCRIPTION
As the tour builds fine on my local machine (however I can currently only build with `Have_botan` or `VibeNoSSL` due to the outstanding issues with OpenSSL 1.1), I thought I (ab)use Travis to reproduce the errors.