### PR TITLE
Make caching faster

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -47,7 +47,7 @@ private IExecProvider createExecProvider(Config config,
 		auto allowedSources = contentProvider.getContent()
 			.map!(x => x.sourceCode.idup)
 			.array;
-		return new Cache(execProvider, 500, 2000, allowedSources);
+		return new Cache(execProvider, allowedSources);
 	}
 	return execProvider;
 }


### PR DESCRIPTION
Imho there has never been a point at making the cache so slow. For example, the GoLang tour doesn't do this as well, e.g.

https://tour.golang.org/welcome/4