### PR TITLE
Use dmd -run instead of rdmd

### DIFF
--- a/source/exec/stupidlocal.d
+++ b/source/exec/stupidlocal.d
@@ -54,13 +54,13 @@ class StupidLocal: IExecProvider
 
 			tmpfile.write(source);
 			tmpfile.close();
-			auto rdmd = execute(["rdmd", tmpfile.name]);
+			auto rdmd = execute(["dmd", "-run", tmpfile.name]);
 			result.success = rdmd.status == 0;
 			result.output = rdmd.output;
 		});
 
 		while (task.running)
-			sleep(300.msecs);
+			sleep(10.msecs);
 
 		return result;
 	}


### PR DESCRIPTION
This is about 40% faster as `rdmd` runs `dmd` twice.

See https://github.com/dlang/tools/pull/194 and https://github.com/dlang/tools/pull/191 (the PR unfortunately got reverted).