### PR TITLE
Increase text width

### DIFF
--- a/views/tour.dt
+++ b/views/tour.dt
@@ -9,7 +9,7 @@ block head
 
 block content
 	.row(ng-controller="DlangTourAppCtrl as ctrl", ng-init="init('#{language}', '#{githubRepo}', '#{chapterId}', '#{section}', #{hasSourceCode}, '#{previousSection.link}', '#{nextSection.link}')")
-		div#tour-content(ng-show="showContent", ng-class="{'col-md-12': !showSourceCode, 'col-md-6 col-sm-12': showSourceCode}")
+		div#tour-content(ng-show="showContent", ng-class="{'col-md-12': !showSourceCode, 'col-md-7 col-sm-12': showSourceCode}")
 			div(ng-hide="showProgramOutput")
 				.content-command-box
 					button.btn.btn-default(ng-click="editOnGithub()")
@@ -25,7 +25,7 @@ block content
 						span.fa.fa-close
 				h2.program-output-title rdmd playground.d
 				pre#program-output {{programOutput}}
-		div(ng-class="{'col-md-6 col-sm-12': showContent, 'col-md-12': !showContent}", ng-show="showSourceCode", style="padding-left: 0px; padding-right: 0px")
+		div(ng-class="{'col-md-5 col-sm-12': showContent, 'col-md-12': !showContent}", ng-show="showSourceCode", style="padding-left: 0px; padding-right: 0px")
 			div#command-box.text-right
 				button.btn.btn-default(ng-click="showContent = !showContent")
 					i.fa.fa-expand(ng-show="showContent",aria-hidden="true")


### PR DESCRIPTION
With the upcoming redesign, we should probably used a fixed width for the example box as there's no point in wasting space if the monospaced text can be at most 48 chars (or even better: use inline examples). However, this is a very quick solution to give the text on the left more space.

![image](https://cloud.githubusercontent.com/assets/4370550/26756040/668eb9ee-489a-11e7-8345-9a8391f2ebd7.png)


![image](https://cloud.githubusercontent.com/assets/4370550/26756038/582fc636-489a-11e7-86d6-951d2cebd38a.png)

(smaller width uses the mobile layout, which is unaffected by this change).