### PR TITLE
Enable ldc-beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ d:
   - ldc
   - ldc-beta
 
-matrix:
-  allow_failures:
-   - d: ldc-beta
-
 cache:
   - $HOME/.dub
 


### PR DESCRIPTION
Seems to be passing as well -> I am enabling it, s.t. we can prevent regressions early on...

![image](https://cloud.githubusercontent.com/assets/4370550/26765870/58869358-4985-11e7-926d-6d7052c15d81.png)
