### PR TITLE
Find available D compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ script:
   # Update all language repos to their latest content
   - git pull --recurse-submodules
   - git submodule update --remote --recursive
-  # Compile & test with DMD
-  - if [[ "${DC}" == "dmd" ]]; then  dub test --compiler=${DC};             fi
-  - if [[ "${DC}" == "dmd" ]]; then  dub --compiler=${DC} -- --sanitycheck; fi
+  # Compile & test with all compilers
+  - dub test --compiler=${DC}
+  - dub --compiler=${DC} -- --sanitycheck
   # Compile to static binary with ldc
   - if [[ "${DC}" == "ldc2" ]]; then  dub build -c static --compiler=${DC}; fi
   - if [[ "${DC}" == "ldc2" ]]; then docker build -t stonemaster/dlang-tour . ; fi


### PR DESCRIPTION
A small oversight from https://github.com/dlang-tour/dlang-tour/pull/528.

As we unfortunately didn't run the tests with LDC, but for the subrepos we do run them with LDC.
Thus, the tests there are now broken with:

```
Task terminated with uncaught exception: Executable file not found: dmd
Task terminated with uncaught exception: Executable file not found: dmd
```

-> I will immediately merge this once CI passes as it's a small, important bug-fix that immediately affects all subrepos.