### PR TITLE
Fix deprecation yaml -> dyaml

### DIFF
--- a/source/config.d
+++ b/source/config.d
@@ -1,4 +1,4 @@
-import yaml;
+import dyaml;
 
 /++
 	Maps values of config.yml to properties.

--- a/source/contentprovider.d
+++ b/source/contentprovider.d
@@ -10,7 +10,7 @@ import std.exception: enforce;
 import std.string: format;
 import std.path: baseName, buildPath;
 
-import yaml;
+import dyaml;
 import mustache;
 
 alias MustacheEngine!(string) Mustache;


### PR DESCRIPTION
Apparently this exists already since a long, long time: https://github.com/dlang-community/D-YAML/commit/be0f967c6c9cef42051935a05ff0c60f115836be