### PR TITLE
Show server error

### DIFF
--- a/public/static/js/tour-controller.js
+++ b/public/static/js/tour-controller.js
@@ -102,7 +102,7 @@ dlangTourApp.controller('DlangTourAppCtrl',
 
 		$http.post('/api/v1/run', {
 			source: $scope.sourceCode
-		}).success(function(data) {
+		}).then(function(data) {
 			$scope.programOutput = data.output;
 			$scope.warnings = data.warnings;
 			$scope.errors = data.errors;
@@ -110,6 +110,9 @@ dlangTourApp.controller('DlangTourAppCtrl',
 			$scope.editor.setOption("lint", {
 				getAnnotations: $scope.updateErrorsAndWarnings
 			});
+		}, function(error) {
+			var msg = (error || {}).statusMessage || "";
+			$scope.programOutput = "Server error: " + msg;
 		});
 	}
 


### PR DESCRIPTION
If one copy/pastes code from somewhere, it's possible to receive an weird UTF error:

```
{"statusMessage":"Invalid UTF-8 sequence (at index 1)","statusDebugMessage":"Invalid UTF sequence: 84x - Invalid UTF-8 sequence (at index 1)"}
```

~~~I don't know how to reproduce this, so I thought it's good to print a helpful error message.~~~ (see below)
Also I copied screenshots from my chrome instance:

Failing:

![image](https://cloud.githubusercontent.com/assets/4370550/26793403/298e7af4-4a1e-11e7-81e6-cfd9cf88d146.png)


Working:

![image](https://cloud.githubusercontent.com/assets/4370550/26793591/d43639e2-4a1e-11e7-9cf4-329f22378670.png)

Minimal example to reproduce:

```d
import std.stdio;
import core.stdc.stdio;
void main()
{
    auto f = 20.66666;
    writefln("%0.3s", f);
    printf("%0.3s\n", f);
}
```

Probably due to a difference between the "stupidlocal" and the Docker driver plus `printf` dumping random memory?